### PR TITLE
Correct sourcehut link

### DIFF
--- a/vc-use-package.el
+++ b/vc-use-package.el
@@ -53,7 +53,7 @@
   '(:github "https://github.com/"
     :gitlab "https://gitlab.com/"
     :codeberg "https://codeberg.org/"
-    :source-hut "https://sr.ht/~")
+    :sourcehut "https://git.sr.ht/~")
   "Places from where to fetch packages.")
 
 (cl-defun vc-use-package--install (&key fetcher repo name rev backend)


### PR DESCRIPTION
Hello!

It seems that https://sr.ht/ URL prefix just directs to the repository summary page. The correct link should point to backend like here: https://git.sr.ht/~protesilaos/modus-themes

I also changed `source-hut` to `sourcehut` as presented on its page.
Thanks for that nifty little package!

Best regards,
alternateved