### PR TITLE
Autoload normalizer and handler functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,8 @@ you don't need to install this package and can instead use `use-package`s own `:
 Install with `package-vc-install`:
 
 ``` emacs-lisp
-(package-vc-install "https://github.com/slotThe/vc-use-package")
-```
-
-After that, simply require the package somewhere in your configuration:
-
-``` emacs-lisp
-(require 'vc-use-package)
-```
-
-More comprehensively:
-
-``` emacs-lisp
 (unless (package-installed-p 'vc-use-package)
   (package-vc-install "https://github.com/slotThe/vc-use-package"))
-(require 'vc-use-package)
 ```
 
 ## Usage

--- a/vc-use-package.el
+++ b/vc-use-package.el
@@ -117,6 +117,7 @@ or a symbol representing one possible destination in
        ((not (plistp arg))
         (use-package-error "Argument given to :vc must be a plist."))))))
 
+;;;###autoload
 (defun use-package-normalize/:vc (name _keyword args)
   (let ((arg (car args)))
     (cl-flet ((spec? (xs)
@@ -132,6 +133,7 @@ or a symbol representing one possible destination in
 
 ;;;; Handler
 
+;;;###autoload
 (defun use-package-handler/:vc (name-symbol _keyword args rest state)
   (let ((body (use-package-process-keywords name-symbol rest state)))
     ;; This happens at macro expansion time, not when the expanded code


### PR DESCRIPTION
This PR marks the `:vc` keyword handler and normalizer functions for autoloading.

Rationale: there's no particular need to load the `vc-use-package` feature, until a `use-package` declaration actually mentions the `:vc` keyword.

For comparison, the handlers for `:diminish`, `:delight`, and `:ensure-system-package` have autoloads.

My use-cases:

I don't often install packages directly from VC. When I do, it's usually a temporary measure. I'd like to have `vc-use-package` available, for the occasions when I need it.

Sometimes I try out a brand new package, which hasn't been added to MELPA yet. When it it does make it into MELPA, I can delete the `:vc` declaration.

Another occasion is when I'm testing (or submitting) a PR to a package. I'll use `:vc` until the PR is merged to the main branch.

(Prior to Emacs 29, I was doing this with quelpa-use-package.)